### PR TITLE
Make surround-pairs-alist buffer local.

### DIFF
--- a/surround.el
+++ b/surround.el
@@ -62,6 +62,7 @@ This only affects inserting pairs, not deleting or changing them."
   :group 'surround
   :type '(repeat (cons (regexp :tag "Key")
                        (symbol :tag "Surround pair"))))
+(make-variable-buffer-local 'surround-pairs-alist)
 
 (defvar surround-read-tag-map
   (let ((map (copy-keymap minibuffer-local-map)))


### PR DESCRIPTION
In different modes it is useful that the same trigger does behave different, so make `surround-paris-alist` a local variable.

For example in markdown-mode it is useful for ` to surround with the default, while in emacs-lisp-mode the pair ` ' is useful and in rst-mode even `` `` makes sense.
