### PR TITLE
Fix markup glitch in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ inserting angle brackets is, so you can add this:
 
 Don't worry about having two entries for `<` surround will take the first.
 
-Or in Emacs Lisp modes using ` to enter ` ' is quite useful, but not adding a
+Or in Emacs Lisp modes using \` to enter \` ' is quite useful, but not adding a
 pair of ` (the default behavior if no entry in `surround-pairs-alist` is
 present), so you can do this:
 


### PR DESCRIPTION
With #8 came a little markup error.

I really tried to avoid using ` as an example, but I couldn't come up with a different example, narf.
