### PR TITLE
Add autoloads for plain emacs functions

### DIFF
--- a/surround.el
+++ b/surround.el
@@ -132,6 +132,7 @@ See also `surround-outer-overlay'."
                                   (evil-range-end inner)
                                   nil nil t))))))
 
+;;;###autoload
 (defun surround-delete (char &optional outer inner)
   "Delete the surrounding delimiters represented by CHAR.
 Alternatively, the text to delete can be represented with
@@ -155,6 +156,7 @@ between these overlays is what is deleted."
         (when outer (delete-overlay outer))
         (when inner (delete-overlay inner)))))))
 
+;;;###autoload
 (defun surround-change (char &optional outer inner)
   "Change the surrounding delimiters represented by CHAR.
 Alternatively, the text to delete can be represented with the


### PR DESCRIPTION
Hey Tim,

This commit just adds two more autoloads allowing the use of `surround-delete` and `surround-change` from emacs without evil-mode.  I love the ability to change wrapped text but I am not currently using evil and this allows me to do that.  Great btw.
