### PR TITLE
Rename surround.el to evil-surround.el

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -1,4 +1,4 @@
-;;; surround.el --- emulate surround.vim from Vim
+;;; evil-surround.el --- emulate surround.vim from Vim
 
 ;; Copyright (C) 2010, 2011 Tim Harper
 ;;
@@ -21,11 +21,11 @@
 ;; The functionality is wrapped into a minor mode. To enable
 ;; it globally, add the following lines to ~/.emacs:
 ;;
-;;     (require 'surround)
-;;     (global-surround-mode 1)
+;;     (require 'evil-surround)
+;;     (global-evil-surround-mode 1)
 ;;
-;; Alternatively, you can enable surround-mode along a major mode
-;; by adding `turn-on-surround-mode' to the mode hook.
+;; Alternatively, you can enable evil-surround-mode along a major mode
+;; by adding `turn-on-evil-surround-mode' to the mode hook.
 ;;
 ;; This package uses Evil as its vi layer. It is available from:
 ;;
@@ -40,7 +40,7 @@
   :prefix "surround-"
   :group 'evil)
 
-(defcustom surround-pairs-alist
+(defcustom evil-surround-pairs-alist
   '((?\( . ("( " . " )"))
     (?\[ . ("[ " . " ]"))
     (?\{ . ("{ " . " }"))
@@ -53,9 +53,9 @@
     (?b . ("(" . ")"))
     (?B . ("{" . "}"))
     (?> . ("<" . ">"))
-    (?t . surround-read-tag)
-    (?< . surround-read-tag)
-    (?f . surround-function))
+    (?t . evil-surround-read-tag)
+    (?< . evil-surround-read-tag)
+    (?f . evil-surround-function))
   "Association list of surround items.
 Each item is of the form (TRIGGER . (LEFT . RIGHT)), all strings.
 Alternatively, a function can be put in place of (LEFT . RIGHT).
@@ -63,9 +63,9 @@ This only affects inserting pairs, not deleting or changing them."
   :group 'surround
   :type '(repeat (cons (regexp :tag "Key")
                        (symbol :tag "Surround pair"))))
-(make-variable-buffer-local 'surround-pairs-alist)
+(make-variable-buffer-local 'evil-surround-pairs-alist)
 
-(defcustom surround-operator-alist
+(defcustom evil-surround-operator-alist
   '((evil-change . change)
     (evil-delete . delete))
   "Association list of operators to their fundamental operation.
@@ -74,31 +74,31 @@ Each item is of the form (OPERATOR . OPERATION)."
   :type '(repeat (cons (symbol :tag "Operator")
                        (symbol :tag "Operation"))))
 
-(defvar surround-read-tag-map
+(defvar evil-surround-read-tag-map
   (let ((map (copy-keymap minibuffer-local-map)))
     (define-key map ">" 'exit-minibuffer)
     map)
-  "Keymap used by `surround-read-tag'.")
+  "Keymap used by `evil-surround-read-tag'.")
 
-(defun surround-function ()
+(defun evil-surround-function ()
   "Read a functionname from the minibuffer and wrap selection in function call"
   (let ((fname (read-from-minibuffer "" "" )))
     (cons (format "%s(" (or fname ""))
           ")")))
 
-(defun surround-read-tag ()
+(defun evil-surround-read-tag ()
   "Read a XML tag from the minibuffer."
-  (let* ((input (read-from-minibuffer "<" "" surround-read-tag-map))
+  (let* ((input (read-from-minibuffer "<" "" evil-surround-read-tag-map))
          (match (string-match "\\([0-9a-z-]+\\)\\(.*?\\)[>]*$" input))
          (tag  (match-string 1 input))
          (rest (match-string 2 input)))
     (cons (format "<%s%s>" (or tag "") (or rest ""))
           (format "</%s>" (or tag "")))))
 
-(defun surround-pair (char)
-  "Return the surround pair of char.
+(defun evil-surround-pair (char)
+  "Return the evil-surround pair of char.
 This is a cons cell (LEFT . RIGHT), both strings."
-  (let ((pair (assoc-default char surround-pairs-alist)))
+  (let ((pair (assoc-default char evil-surround-pairs-alist)))
     (cond
      ((functionp pair)
       (funcall pair))
@@ -109,20 +109,20 @@ This is a cons cell (LEFT . RIGHT), both strings."
      (t
       (cons (format "%c" char) (format "%c" char))))))
 
-(defun surround-outer-overlay (char)
+(defun evil-surround-outer-overlay (char)
   "Return outer overlay for the delimited range represented by CHAR.
 This overlay includes the delimiters.
-See also `surround-inner-overlay'."
+See also `evil-surround-inner-overlay'."
   (let ((outer (lookup-key evil-outer-text-objects-map (string char))))
     (when (functionp outer)
       (setq outer (funcall outer))
       (when (evil-range-p outer)
-        (surround-trim-whitespace-from-range outer "[[:space:]]")
+        (evil-surround-trim-whitespace-from-range outer "[[:space:]]")
         (setq outer (make-overlay (evil-range-beginning outer)
                                   (evil-range-end outer)
                                   nil nil t))))))
 
-(defun surround-trim-whitespace-from-range (range &optional regexp)
+(defun evil-surround-trim-whitespace-from-range (range &optional regexp)
   "Given an evil-range, trim whitespace around range by shrinking the range such that it neither begins nor ends with whitespace. Does not modify the buffer."
   (let ((regexp (or regexp "[ \f\t\n\r\v]")))
     (save-excursion
@@ -134,21 +134,21 @@ See also `surround-inner-overlay'."
         (while (looking-back regexp) (backward-char))
         (evil-set-range-end range (point))))))
 
-(defun surround-inner-overlay (char)
+(defun evil-surround-inner-overlay (char)
   "Return inner overlay for the delimited range represented by CHAR.
 This overlay excludes the delimiters.
-See also `surround-outer-overlay'."
+See also `evil-surround-outer-overlay'."
   (let ((inner (lookup-key evil-inner-text-objects-map (string char))))
     (when (functionp inner)
       (setq inner (funcall inner))
       (when (evil-range-p inner)
         (when (eq (char-syntax char) ?\()
-          (surround-trim-whitespace-from-range inner "[[:space:]]"))
+          (evil-surround-trim-whitespace-from-range inner "[[:space:]]"))
         (setq inner (make-overlay (evil-range-beginning inner)
                                   (evil-range-end inner)
                                   nil nil t))))))
 
-(evil-define-motion surround-line (count)
+(evil-define-motion evil-surround-line (count)
   "Move COUNT - 1 lines down but return exclusive character motion."
   :type exclusive
   (let ((beg (line-beginning-position)))
@@ -159,7 +159,7 @@ See also `surround-outer-overlay'."
       range)))
 
 ;;;###autoload
-(defun surround-delete (char &optional outer inner)
+(defun evil-surround-delete (char &optional outer inner)
   "Delete the surrounding delimiters represented by CHAR.
 Alternatively, the text to delete can be represented with
 the overlays OUTER and INNER, where OUTER includes the delimiters
@@ -174,57 +174,57 @@ between these overlays is what is deleted."
    (t
     ;; no overlays specified: create them on the basis of CHAR
     ;; and delete after use
-    (let* ((outer (surround-outer-overlay char))
-           (inner (surround-inner-overlay char)))
+    (let* ((outer (evil-surround-outer-overlay char))
+           (inner (evil-surround-inner-overlay char)))
       (unwind-protect
           (when (and outer inner)
-            (surround-delete char outer inner))
+            (evil-surround-delete char outer inner))
         (when outer (delete-overlay outer))
         (when inner (delete-overlay inner)))))))
 
 ;;;###autoload
-(defun surround-change (char &optional outer inner)
+(defun evil-surround-change (char &optional outer inner)
   "Change the surrounding delimiters represented by CHAR.
 Alternatively, the text to delete can be represented with the
-overlays OUTER and INNER, which are passed to `surround-delete'."
+overlays OUTER and INNER, which are passed to `evil-surround-delete'."
   (interactive "c")
   (cond
    ((and outer inner)
-    (surround-delete char outer inner)
-    (surround-region (overlay-start outer)
+    (evil-surround-delete char outer inner)
+    (evil-surround-region (overlay-start outer)
                      (overlay-end outer)
                      nil (read-char)))
    (t
-    (let* ((outer (surround-outer-overlay char))
-           (inner (surround-inner-overlay char)))
+    (let* ((outer (evil-surround-outer-overlay char))
+           (inner (evil-surround-inner-overlay char)))
       (unwind-protect
           (when (and outer inner)
-            (surround-change char outer inner))
+            (evil-surround-change char outer inner))
         (when outer (delete-overlay outer))
         (when inner (delete-overlay inner)))))))
 
 ;; Dispatcher function in Operator-Pending state.
-;; "cs" calls `surround-change', "ds" calls `surround-delete',
-;; and "ys" calls `surround-region'.
-(evil-define-command surround-edit (operation)
+;; "cs" calls `evil-surround-change', "ds" calls `evil-surround-delete',
+;; and "ys" calls `evil-surround-region'.
+(evil-define-command evil-surround-edit (operation)
   "Edit the surrounding delimiters represented by CHAR.
-If OPERATION is `change', call `surround-change'.
-if OPERATION is `surround', call `surround-region'.
-Otherwise call `surround-delete'."
+If OPERATION is `change', call `evil-surround-change'.
+if OPERATION is `surround', call `evil-surround-region'.
+Otherwise call `evil-surround-delete'."
   (interactive
    (progn
      ;; abort the calling operator
      (setq evil-inhibit-operator t)
      (list (assoc-default evil-this-operator
-                          surround-operator-alist))))
+                          evil-surround-operator-alist))))
   (cond
    ((eq operation 'change)
-    (call-interactively 'surround-change))
+    (call-interactively 'evil-surround-change))
    ((eq operation 'delete)
-    (call-interactively 'surround-delete))
+    (call-interactively 'evil-surround-delete))
    (t
-    (define-key evil-operator-shortcut-map "s" 'surround-line)
-    (call-interactively 'surround-region))))
+    (define-key evil-operator-shortcut-map "s" 'evil-surround-line)
+    (call-interactively 'evil-surround-region))))
 
 (evil-define-operator surround-region (beg end type char &optional force-new-line)
   "Surround BEG and END with CHAR.
@@ -242,7 +242,7 @@ Becomes this:
 
   (interactive "<R>c")
   (let* ((overlay (make-overlay beg end nil nil t))
-         (pair (surround-pair char))
+         (pair (evil-surround-pair char))
          (open (car pair))
          (close (cdr pair)))
     (unwind-protect
@@ -276,33 +276,33 @@ Becomes this:
 (evil-define-operator Surround-region (beg end type char)
   "Call surround-region, toggling force-new-line"
   (interactive "<R>c")
-  (surround-region beg end type char t))
+  (evil-surround-region beg end type char t))
 
 ;;;###autoload
-(define-minor-mode surround-mode
+(define-minor-mode evil-surround-mode
   "Buffer-local minor mode to emulate surround.vim."
   :keymap (make-sparse-keymap)
   (evil-normalize-keymaps))
 
 ;;;###autoload
-(defun turn-on-surround-mode ()
-  "Enable surround-mode in the current buffer."
-  (surround-mode 1))
+(defun turn-on-evil-surround-mode ()
+  "Enable evil-surround-mode in the current buffer."
+  (evil-surround-mode 1))
 
 ;;;###autoload
-(defun turn-off-surround-mode ()
-  "Disable surround-mode in the current buffer."
-  (surround-mode -1))
+(defun turn-off-evil-surround-mode ()
+  "Disable evil-surround-mode in the current buffer."
+  (evil-surround-mode -1))
 
 ;;;###autoload
-(define-globalized-minor-mode global-surround-mode
-  surround-mode turn-on-surround-mode
+(define-globalized-minor-mode global-evil-surround-mode
+  evil-surround-mode turn-on-evil-surround-mode
   "Global minor mode to emulate surround.vim.")
 
-(evil-define-key 'operator surround-mode-map "s" 'surround-edit)
-(evil-define-key 'visual surround-mode-map "s" 'surround-region)
-(evil-define-key 'visual surround-mode-map "S" 'Surround-region)
+(evil-define-key 'operator evil-surround-mode-map "s" 'evil-surround-edit)
+(evil-define-key 'visual evil-surround-mode-map "s" 'evil-surround-region)
+(evil-define-key 'visual evil-surround-mode-map "S" 'evil-Surround-region)
 
-(provide 'surround)
+(provide 'evil-surround)
 
-;;; surround.el ends here
+;;; evil-surround.el ends here


### PR DESCRIPTION
That way the MELPA recipe can be named "evil-surround" instead of "surround".

It doesn't make sense for this file to be named "surround.el" as it is an extension of `evil`.

See #27 for a rationale, also https://github.com/milkypostman/melpa/issues/1778
