### PR TITLE
use read-key instead of read-char -- handles unicode better

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -202,7 +202,7 @@ overlays OUTER and INNER, which are passed to `evil-surround-delete'."
   (cond
    ((and outer inner)
     (evil-surround-delete char outer inner)
-    (let ((key (read-char)))
+    (let ((key (read-key)))
       (evil-surround-region (overlay-start outer)
                             (overlay-end outer)
                             nil (if (evil-surround-valid-char-p key) key char))))


### PR DESCRIPTION
`read-char` in the terminal will read only part of a multibyte unicode character input from the keyboard, whereas `read-key` reads the whole thing.  This goes along with a pull request I've sent to the evil repository to fix the same thing (https://github.com/emacs-evil/evil/pull/857).