### PR TITLE
use the `inherit-input-method` argument for read-char

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -202,7 +202,7 @@ overlays OUTER and INNER, which are passed to `evil-surround-delete'."
   (cond
    ((and outer inner)
     (evil-surround-delete char outer inner)
-    (let ((key (read-char)))
+    (let ((key (read-char nil t)))
       (evil-surround-region (overlay-start outer)
                             (overlay-end outer)
                             nil (if (evil-surround-valid-char-p key) key char))))

--- a/test/evil-surround-test.el
+++ b/test/evil-surround-test.el
@@ -15,6 +15,18 @@
       ("ds'")
       "one two three")))
 
+(ert-deftest evil-surround-dot-test ()
+  (ert-info ("basic surrounding")
+    (evil-test-buffer
+      "one ((([t]wo))) three"
+      (turn-on-evil-surround-mode)
+      ("cs)]")
+      "one (([two])) three"
+      (".")
+      "one ([[two]]) three"
+      (".")
+      "one [[[two]]] three")))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; code below is copied from evil-tests.el
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Supercedes #114 -- this one doesn't break `.`.