### PR TITLE
Add support for evil-want-change-word-to-end to evil-surround

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -381,6 +381,11 @@ Becomes this:
 (evil-define-key 'visual evil-surround-mode-map "S" 'evil-surround-region)
 (evil-define-key 'visual evil-surround-mode-map "gS" 'evil-Surround-region)
 
+;; This lets 'ysw)' behave the same as 'ysiw)', by treating 'evil-yank'
+;; like 'evil-change'.
+(when (boundp 'evil-change-commands)
+  (add-to-list 'evil-change-commands #'evil-yank))
+
 (provide 'evil-surround)
 
 ;;; evil-surround.el ends here


### PR DESCRIPTION
I recently added the changes suggested in #117 to evil (https://github.com/emacs-evil/evil/issues/916), which enables evil-surround to respect `evil-want-change-word-to-end`. I didn't read in too much into the evil-surround implementation, so I went for the simplest way I could think of.

Unfortunately, the 'command' that's running during a 'ysw)' is 'evil-yank', so this adds 'evil-yank' to the 'change-commands' list. That is a bit hacky, but I'm not sure if there's a better way to do this (other than evil-surround redefining 'y', which I wouldn't prefer).

If you think this is 'too hacky' that's fine (I think it is, to be fair), I'm just not sure how to attempt to fix the problem if that's the case.

Let me know if you think there's a better way to do this, or if you find any problems after the patch.

Closes #117 