### PR TITLE
Add examples from readme as automated tests

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -258,7 +258,6 @@ If OPERATION is `change', call `evil-surround-change'.
 if OPERATION is `delete', call `evil-surround-delete'.
 Otherwise call `evil-surround-region'."
   (interactive (evil-surround-interactive-setup))
-  (message "%s" operation)
   (cond
    ((eq operation 'change)
     (call-interactively 'evil-surround-change))
@@ -273,7 +272,6 @@ Otherwise call `evil-surround-region'."
 
 It does nothing for change / delete."
   (interactive (evil-surround-interactive-setup))
-  (message "%s" operation)
   (cond
    ((eq operation 'change) nil)
    ((eq operation 'delete) nil)

--- a/test/evil-surround-test.el
+++ b/test/evil-surround-test.el
@@ -14,4 +14,28 @@
       ("csb'")
       "one 'two' three"
       ("ds'")
-      "one two three")))
+      "one two three"))
+  (ert-info ("examples from readme")
+    (evil-test-buffer
+      :visual-start nil
+      :visual-end nil
+      "\"Hello world!\""
+      (turn-on-evil-surround-mode)
+      ("cs\"'")
+      "'Hello world!'"
+      ("cs'<q>")
+      "<q>Hello world!</q>"
+      ("cst\"")
+      "\"Hello world!\""
+      ("ds\"")
+      "Hello world!"
+      ("ysiw]")
+      "[Hello] world!"
+      ("cs[{")
+      "{ Hello } world!"
+      ("yssb")
+      "({ Hello } world!)"
+      ("lds{ds)") ;; 'l' to move the cursor right, inside brackets
+      "Hello world!"
+      ("ysiw<em>")
+      "<em>Hello</em> world!")))


### PR DESCRIPTION
This PR adds the the `Examples` from the readme as unit tests, all but the last one. I couldn't get the last one working. Here's what I tried in case someone wants to pick it up.

```
(evil-test-buffer
      :visual-start nil
      :visual-start nil
      "<em>Hello</em> world!"
      ("VS<p class=\"important\">")
      "<p class=\"important\">\n<em>Hello</em> world!\n</p>")
```

The issue has something to do with `evil-test-buffer` using `<` and `>` as visual selection.

Still, even without the last one, I think this is a good addition to the test suite.
