### PR TITLE
When motion is 'word' and evil-want-change-word-to-end is t, behave like 'ce', not 'cw'

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -296,6 +296,10 @@ Becomes this:
    }"
 
   (interactive "<R>c")
+
+  ;; if motion is 'word' and evil-want-change-word-to-end is t, behave like 'ce', not 'cw'
+  (when (and (eq evil-this-motion 'evil-forward-word-begin) evil-want-change-word-to-end)
+    (setq end (1- end)))
   (when (evil-surround-valid-char-p char)
     (let* ((overlay (make-overlay beg end nil nil t))
            (pair (or (and (boundp 'pair) pair) (evil-surround-pair char)))


### PR DESCRIPTION
This seems like a simple solution to #117 

@ninrod let me know if you think this approach is OK, and I'll add tests.

#120 should probably be merged first though, so we get better test coverage when this is merged.