### PR TITLE
Surround word should behave like 'ce', not 'cw'

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -44,6 +44,10 @@
   :prefix "surround-"
   :group 'evil)
 
+;; make surround's `ysw' work like `cw', not `ce'
+(when (boundp 'evil-change-commands)
+  (add-to-list 'evil-change-commands 'evil-surround-region))
+
 (defcustom evil-surround-pairs-alist
   '((?\( . ("( " . " )"))
     (?\[ . ("[ " . " ]"))
@@ -245,6 +249,12 @@ This is necessary because `evil-yank' operator is not repeatable (:repeat nil)"
   (evil-repeat-start)
   (evil-repeat-record "y")
   (evil-repeat-record (this-command-keys))
+
+  ;; set `this-command-keys' to the command that will be executed
+  ;; interactively; as a result, `evil-this-operator' will be
+  ;; correctly set to, for example, `evil-surround-region' instead of
+  ;; `evil-yank' when surround has been invoked by `ys'
+  (setq this-command callback)
   (call-interactively callback)
   (evil-repeat-keystrokes 'post)
   (evil-repeat-stop))
@@ -309,8 +319,8 @@ Becomes this:
                   ((eq type 'line)
                    (setq force-new-line
                          (or force-new-line
-                             ;; Force newline if not invoked from an operator, e.g. VS)
-                             (eq evil-this-operator 'evil-surround-region)
+                             ;; Force newline if not invoked from an operator, e.g. visual line mode with VS)
+                             (evil-visual-state-p)
                              ;; Or on multi-line operator surrounds (like 'ysj]')
                              (/= (line-number-at-pos) (line-number-at-pos (1- end)))))
 

--- a/test/evil-surround-test.el
+++ b/test/evil-surround-test.el
@@ -96,4 +96,33 @@
       "111 222 333\n[1]11 222 333\n111 222 333\n111 222 333\n"
       (turn-on-evil-surround-mode)
       ("ysjb")
-      "111 222 333\n(\n111 222 333\n111 222 333\n)\n111 222 333\n")))
+      "111 222 333\n(\n111 222 333\n111 222 333\n)\n111 222 333\n"))
+  (ert-info ("test with evil-want-change-word-to-end")
+    (evil-test-buffer
+      "[o]ne    two  three"
+      (setq evil-want-change-word-to-end nil)
+      (turn-on-evil-surround-mode)
+      ("yswb")
+      "[(]one    )two  three"
+      ("dsb")
+      "[o]ne    two  three"
+      ("ys2wb")
+      "[(]one    two  )three"
+      ("dsb")
+      "[o]ne    two  three"
+      ("ys3wb")
+      "[(]one    two  three)")
+    (evil-test-buffer
+      "[o]ne    two  three"
+      (setq evil-want-change-word-to-end t)
+      (turn-on-evil-surround-mode)
+      ("yswb")
+      "[(]one)    two  three"
+      ("dsb")
+      "[o]ne    two  three"
+      ("ys2wb")
+      "[(]one    two)  three"
+      ("dsb")
+      "[o]ne    two  three"
+      ("ys3wb")
+      "[(]one    two  three)")))

--- a/test/evil-surround-test.el
+++ b/test/evil-surround-test.el
@@ -38,4 +38,62 @@
       ("lds{ds)") ;; 'l' to move the cursor right, inside brackets
       "Hello world!"
       ("ysiw<em>")
-      "<em>Hello</em> world!")))
+      "<em>Hello</em> world!"))
+  (ert-info ("repeat surrounding")
+    (evil-test-buffer
+      "[o]ne two three"
+      (turn-on-evil-surround-mode)
+      ;; surround and repeat it
+      ("ysiwb")
+      "(one) two three"
+      ("W.") ;; repeat surround region
+      "(one) (two) three"
+      ("W.") ;; repeat surround region
+      "(one) (two) (three)"
+
+      ;; change surround and repeat it
+      ("0csb'")
+      "'one' (two) (three)"
+      ("W.") ;; repeat change surround
+      "'one' 'two' (three)"
+      ("W.") ;; repeat change surround
+      "'one' 'two' 'three'"
+
+      ;; delete surround and repeat it
+      ("0ds'")
+      "one 'two' 'three'"
+      ("W.") ;; repeat delete surround
+      "one two 'three'"
+      ("W.") ;; repeat delete surround
+      "one two three"))
+  (ert-info ("visual surrounding")
+    (evil-test-buffer
+      "<one two> three\nfour\n"
+      (turn-on-evil-surround-mode)
+      ("Sb")
+      "(one two) three\nfour\n")
+    (evil-test-buffer
+      "<one two three>\nfour\n"
+      (turn-on-evil-surround-mode)
+      ("Sb")
+      "(one two three)\nfour\n")
+    (evil-test-buffer
+      "<one two three\nfo>ur\n"
+      (turn-on-evil-surround-mode)
+      ("Sb")
+      "(one two three\nfo)ur\n"))
+  (ert-info ("visual line surrounding")
+    (evil-test-buffer
+      "[o]ne two three\nfour\n"
+      (turn-on-evil-surround-mode)
+      ("yssb")
+      "(one two three)\nfour\n"
+      ("dsb")
+      "one two three\nfour\n"
+      ("VSb")
+      "(\none two three\n)\nfour\n")
+    (evil-test-buffer
+      "111 222 333\n[1]11 222 333\n111 222 333\n111 222 333\n"
+      (turn-on-evil-surround-mode)
+      ("ysjb")
+      "111 222 333\n(\n111 222 333\n111 222 333\n)\n111 222 333\n")))

--- a/test/make-test.el
+++ b/test/make-test.el
@@ -1,3 +1,4 @@
+(setq load-prefer-newer t)
 
 (let ((current-directory (file-name-directory load-file-name)))
   (setq evil-surround-test-path (expand-file-name "." current-directory))


### PR DESCRIPTION
When motion is 'word' and evil-want-change-word-to-end is t, re-run
the motion with `evil-this-operator` explicitly set to
`evil-surround-region`