### PR TITLE
Use ‘evil-surround’ as :group for customizable variables

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -39,9 +39,9 @@
 
 (require 'evil)
 
-(defgroup surround nil
+(defgroup evil-surround nil
   "surround.vim for Emacs"
-  :prefix "surround-"
+  :prefix "evil-surround-"
   :group 'evil)
 
 ;; make surround's `ysw' work like `cw', not `ce'
@@ -68,7 +68,7 @@
 Each item is of the form (TRIGGER . (LEFT . RIGHT)), all strings.
 Alternatively, a function can be put in place of (LEFT . RIGHT).
 This only affects inserting pairs, not deleting or changing them."
-  :group 'surround
+  :group 'evil-surround
   :type '(alist
           :key-type (character :tag "Key")
           :value-type (choice
@@ -81,7 +81,7 @@ This only affects inserting pairs, not deleting or changing them."
     (evil-delete . delete))
   "Association list of operators to their fundamental operation.
 Each item is of the form (OPERATOR . OPERATION)."
-  :group 'surround
+  :group 'evil-surround
   :type '(repeat (cons (symbol :tag "Operator")
                        (symbol :tag "Operation"))))
 


### PR DESCRIPTION
Before this change, there were two groups for this package in the
customize interface. The customizable variables show up in the group
named ‘surround’, while the mode itself shows up in the group named
‘evil-surround’. This is confusing and unnecessary.

To address this, put everything inside the ‘evil-surround’ group,
which is the same approach used by many other evil-mode extension
packages.