### PR TITLE
Fix regression for Emacs 26 caused by #125 fix

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -96,7 +96,7 @@ Each item is of the form (OPERATOR . OPERATION)."
 
 (defun evil-surround-read-from-minibuffer (&rest args)
   (when evil-surround-record-repeat
-    (evil-repeat-record (evil-this-command-keys)))
+    (evil-repeat-keystrokes 'post))
   (let ((res (apply #'read-from-minibuffer args)))
     (when evil-surround-record-repeat
       (evil-repeat-record res))


### PR DESCRIPTION
Emacs 26 saves this-command-keys across read-from-minibuffer, so make sure
this-command-keys is cleared when we record it before read-from-minibuffer.

Fixes #131