### PR TITLE
Fix visible narrowing when surrounding within a field

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -102,6 +102,21 @@ Each item is of the form (OPERATOR . OPERATION)."
       (evil-repeat-record res))
     res))
 
+;; The operator state narrows the buffer to the current field. This
+;; function widens temporarily before reading a character so the
+;; narrowing is not visible to the user.
+(defun evil-surround-read-char ()
+  (if (evil-operator-state-p)
+      (save-restriction (widen) (read-char))
+    (read-char)))
+
+(defun evil-surround-input-char ()
+  (list (evil-surround-read-char)))
+
+(defun evil-surround-input-region-char ()
+  (append (evil-operator-range t)
+          (evil-surround-input-char)))
+
 (defun evil-surround-function ()
   "Read a functionname from the minibuffer and wrap selection in function call"
   (let ((fname (evil-surround-read-from-minibuffer "" "")))
@@ -191,7 +206,7 @@ Alternatively, the text to delete can be represented with
 the overlays OUTER and INNER, where OUTER includes the delimiters
 and INNER excludes them. The intersection (i.e., difference)
 between these overlays is what is deleted."
-  (interactive "c")
+  (interactive (evil-surround-input-char))
   (cond
    ((and outer inner)
     (delete-region (overlay-start outer) (overlay-start inner))
@@ -213,11 +228,11 @@ between these overlays is what is deleted."
   "Change the surrounding delimiters represented by CHAR.
 Alternatively, the text to delete can be represented with the
 overlays OUTER and INNER, which are passed to `evil-surround-delete'."
-  (interactive "c")
+  (interactive (evil-surround-input-char))
   (cond
    ((and outer inner)
     (evil-surround-delete char outer inner)
-    (let ((key (read-char)))
+    (let ((key (evil-surround-read-char)))
       (evil-surround-region (overlay-start outer)
                             (overlay-end outer)
                             nil (if (evil-surround-valid-char-p key) key char))))
@@ -315,7 +330,7 @@ Becomes this:
      :thing
    }"
 
-  (interactive "<R>c")
+  (interactive (evil-surround-input-region-char))
   (when (evil-surround-valid-char-p char)
     (let* ((overlay (make-overlay beg end nil nil t))
            (pair (or (and (boundp 'pair) pair) (evil-surround-pair char)))
@@ -371,7 +386,7 @@ Becomes this:
 
 (evil-define-operator evil-Surround-region (beg end type char)
   "Call surround-region, toggling force-new-line"
-  (interactive "<R>c")
+  (interactive (evil-surround-input-region-char))
   (evil-surround-region beg end type char t))
 
 ;;;###autoload


### PR DESCRIPTION
In operator state the buffer is narrowed to the current Emacs field. This narrowing becomes visible when waiting for user input which is quite disruptive of the workflow. This patch widens the buffer before reading a character to avoid this.

For some context see https://github.com/emacs-evil/evil/issues/294 and https://gitorious.org/evil/cofis-evil/commit/bcf0bac?p=evil:cofis-evil.git;a=blobdiff;f=evil-types.el;h=3d963fb271013319566e923cde210af616369e0c;hp=b850569f868e994cb04236fb0f1ce614d230a722;hb=bcf0bac;hpb=ef4f5b8a74199731b08e0737027d7cb92c9e2a77.