### PR TITLE
use @lionel- PR and revert @Dickby's PR

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -76,34 +76,6 @@ This only affects inserting pairs, not deleting or changing them."
                        (function :tag "Function"))))
 (make-variable-buffer-local 'evil-surround-pairs-alist)
 
-(defcustom evil-surround-lisp-modes '(
-				      cider-repl-mode
-				      clojure-mode
-				      clojurec-mode
-				      clojurescript-mode
-				      clojurex-mode
-				      common-lisp-mode
-				      emacs-lisp-mode
-				      eshell-mode
-				      geiser-repl-mode
-				      inf-clojure-mode
-				      inferior-emacs-lisp-mode
-				      inferior-lisp-mode
-				      inferior-scheme-mode
-				      lisp-interaction-mode
-				      lisp-mode
-				      monroe-mode
-				      racket-mode
-				      racket-repl-mode
-				      scheme-interaction-mode
-				      scheme-mode
-				      slime-repl-mode
-				      stumpwm-mode
-				      )
-  "List of Lisp-related modes."
-  :type '(repeat symbol)
-  :group 'evil-surround)
-
 (defcustom evil-surround-operator-alist
   '((evil-change . change)
     (evil-delete . delete))
@@ -148,9 +120,8 @@ Each item is of the form (OPERATOR . OPERATION)."
 (defun evil-surround-function ()
   "Read a functionname from the minibuffer and wrap selection in function call"
   (let ((fname (evil-surround-read-from-minibuffer "" "")))
-    (cons (format (if (member major-mode evil-surround-lisp-modes)
-		      "(%s " "%s(")
-		  (or fname "")) ")")))
+    (cons (format "%s(" (or fname ""))
+          ")")))
 
 (defun evil-surround-read-tag ()
   "Read a XML tag from the minibuffer."
@@ -201,7 +172,7 @@ See also `evil-surround-inner-overlay'."
         (while (looking-at regexp) (forward-char))
         (evil-set-range-beginning range (point))
         (goto-char (evil-range-end range))
-        (while (looking-back regexp nil) (backward-char))
+        (while (looking-back regexp) (backward-char))
         (evil-set-range-end range (point))))))
 
 (defun evil-surround-inner-overlay (char)

--- a/evil-surround.el
+++ b/evil-surround.el
@@ -130,6 +130,21 @@ Each item is of the form (OPERATOR . OPERATION)."
       (evil-repeat-record res))
     res))
 
+;; The operator state narrows the buffer to the current field. This
+;; function widens temporarily before reading a character so the
+;; narrowing is not visible to the user.
+(defun evil-surround-read-char ()
+  (if (evil-operator-state-p)
+      (save-restriction (widen) (read-char))
+    (read-char)))
+
+(defun evil-surround-input-char ()
+  (list (evil-surround-read-char)))
+
+(defun evil-surround-input-region-char ()
+  (append (evil-operator-range t)
+          (evil-surround-input-char)))
+
 (defun evil-surround-function ()
   "Read a functionname from the minibuffer and wrap selection in function call"
   (let ((fname (evil-surround-read-from-minibuffer "" "")))
@@ -220,7 +235,7 @@ Alternatively, the text to delete can be represented with
 the overlays OUTER and INNER, where OUTER includes the delimiters
 and INNER excludes them. The intersection (i.e., difference)
 between these overlays is what is deleted."
-  (interactive "c")
+  (interactive (evil-surround-input-char))
   (cond
    ((and outer inner)
     (delete-region (overlay-start outer) (overlay-start inner))
@@ -242,11 +257,11 @@ between these overlays is what is deleted."
   "Change the surrounding delimiters represented by CHAR.
 Alternatively, the text to delete can be represented with the
 overlays OUTER and INNER, which are passed to `evil-surround-delete'."
-  (interactive "c")
+  (interactive (evil-surround-input-char))
   (cond
    ((and outer inner)
     (evil-surround-delete char outer inner)
-    (let ((key (read-char)))
+    (let ((key (evil-surround-read-char)))
       (evil-surround-region (overlay-start outer)
                             (overlay-end outer)
                             nil (if (evil-surround-valid-char-p key) key char))))
@@ -344,7 +359,7 @@ Becomes this:
      :thing
    }"
 
-  (interactive "<R>c")
+  (interactive (evil-surround-input-region-char))
   (when (evil-surround-valid-char-p char)
     (let* ((overlay (make-overlay beg end nil nil t))
            (pair (or (and (boundp 'pair) pair) (evil-surround-pair char)))
@@ -400,7 +415,7 @@ Becomes this:
 
 (evil-define-operator evil-Surround-region (beg end type char)
   "Call surround-region, toggling force-new-line"
-  (interactive "<R>c")
+  (interactive (evil-surround-input-region-char))
   (evil-surround-region beg end type char t))
 
 ;;;###autoload

--- a/test/evil-surround-test.el
+++ b/test/evil-surround-test.el
@@ -67,21 +67,10 @@
       :visual-end nil
       "argument1 argument2"
       (turn-on-evil-surround-mode)
-      (c-mode)
       ("ysiwffunction" [return])
       "function(argument1) argument2"
       ("W.")
-      "function(argument1) function(argument2)")
-    (evil-test-buffer
-      :visual-start nil
-      :visual-end nil
-      "argument1 argument2"
-      (turn-on-evil-surround-mode)
-      (emacs-lisp-mode)
-      ("ysiwffunction" [return])
-      "(function argument1) argument2"
-      ("$.")
-      "(function argument1) (function argument2)"))
+      "function(argument1) function(argument2)"))
   (ert-info ("even more examples from readme: tag surrounding with dot repeat")
     (evil-test-buffer
       :visual-start nil

--- a/test/evil-surround-test.el
+++ b/test/evil-surround-test.el
@@ -14,6 +14,18 @@
  ?\[ '("[ " . " ]")
  ?\{ '("{ " . " }"))
 
+(defmacro test-widened-buffer (start cmds exp)
+  (declare (indent 0))
+  `(let (widened)
+     (evil-test-buffer
+       ,start
+       (turn-on-evil-surround-mode)
+       (cl-letf (((symbol-function #'widen)
+                  (lambda () (setq widened t))))
+         (execute-kbd-macro ,(car cmds)))
+       ,exp)
+     (should widened)))
+
 (ert-deftest evil-surround-test ()
   (ert-info ("basic surrounding")
     (evil-test-buffer
@@ -180,4 +192,17 @@
       (turn-on-evil-surround-mode)
       ("cs`)")
       "[(]this_is_a_backtick_surrounded_word)"
-      )))
+      ))
+  (ert-info ("buffer is widened before reading char")
+    (test-widened-buffer
+      "`[w]ord`"
+      ("cs`)")
+      "[(]word)")
+    (test-widened-buffer
+      "`[w]ord`"
+      ("ds`")
+      "[w]ord")
+    (test-widened-buffer
+      "[w]ord"
+      ("ysiwb")
+      "[(]word)")))


### PR DESCRIPTION
this PR is an experiment. I'm almost sure that @Dickby's [commit](https://github.com/emacs-evil/evil-surround/commit/5a20c9757eff64e1567d313eb254126aef2bf3b2) caused the surround function test to begin to fail, although travis did not catch it because `make test` is returning 0 on test failures.

Here I use @lionel-'s PR #135 and revert 5a20c9757 on top of it.