### PR TITLE
optionally keep xml attributes

### DIFF
--- a/test/evil-surround-test.el
+++ b/test/evil-surround-test.el
@@ -93,6 +93,16 @@
       "<a>tag1</a> tag2"
       ("W.")
       "<a>tag1</a> <a>tag2</a>"))
+  (ert-info ("optionally keep xml attributes")
+    (evil-test-buffer
+      :visual-start nil
+      :visual-end nil
+      "<div class=\"foo\">Bar</div>"
+      (turn-on-evil-surround-mode)
+      ("cst<span")
+      "<span class=\"foo\">Bar</span>"
+      ("cst<p>")
+      "<p>Bar</p>"))
   (ert-info ("repeat surrounding")
     (evil-test-buffer
       "[o]ne two three"


### PR DESCRIPTION
Closes #150.

From Vim Surround for reference:
> If t or < is used, Vim prompts for an HTML/XML tag to insert.  You may specify
> attributes here and they will be stripped from the closing tag. **If replacing a
> tag, its attributes are kept in the new tag. End your input with > to discard
> the those attributes.** If \<C-T> is used, the tags will appear on lines by
> themselves.