### PR TITLE
Add dots and caps to evil-surround-tag-name-re

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -134,7 +134,7 @@ Each item is of the form (OPERATOR . OPERATION)."
     (cons (format "%s(" (or fname ""))
           ")")))
 
-(defconst evil-surround-tag-name-re "\\([0-9a-z-]+\\)"
+(defconst evil-surround-tag-name-re "\\([0-9a-zA-Z\.-]+\\)"
   "Regexp matching an XML tag name.")
 
 (defun evil-surround-tag-p (string)

--- a/test/evil-surround-test.el
+++ b/test/evil-surround-test.el
@@ -73,6 +73,22 @@
       "Hello world!"
       ("ysiw<em>")
       "<em>Hello</em> world!"))
+  (ert-info ("tests for dots and caps support in tags")
+	(evil-test-buffer
+	 :visual-start nil
+	 :visual-end nil
+	 "\"Hello world!\""
+	 (turn-on-evil-surround-mode)
+	 ("cs\"'")
+	 "'Hello world!'"
+	 ("cs'<Table.Hi>")
+	 "<Table.Hi>Hello world!</Table.Hi>"
+	 ("dst")
+	 "Hello world!"
+	 ("ysiw<div.Test attr=\"true\">")
+	 "<div.Test attr=\"true\">Hello</div.Test> world!"
+	 ("cst<Three.Separate.Components>")
+	 "<Three.Separate.Components>Hello</Three.Separate.Components> world!"))
   (ert-info ("more examples from readme: function surrounding with dot repeat")
     (evil-test-buffer
       :visual-start nil


### PR DESCRIPTION
I've tested this and it seems to work for my use case, this should take care of the issue I opened in #155, please advice if you see something wrong or some potentially breaking change.

thank you for creating this plugin :+1: 