### PR TITLE
Fix repeating tag changes

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -106,10 +106,12 @@ Each item is of the form (OPERATOR . OPERATION)."
   "The previously deleted LEFT region.")
 
 (defun evil-surround-read-from-minibuffer (&rest args)
-  (when evil-surround-record-repeat
+  (when (or evil-surround-record-repeat
+            (evil-repeat-recording-p))
     (evil-repeat-keystrokes 'post))
   (let ((res (apply #'read-from-minibuffer args)))
-    (when evil-surround-record-repeat
+    (when (or evil-surround-record-repeat
+              (evil-repeat-recording-p))
       (evil-repeat-record res))
     res))
 

--- a/test/evil-surround-test.el
+++ b/test/evil-surround-test.el
@@ -129,6 +129,16 @@
       "<span ngModel class=\"foo\" randomAngularDirective #anchor1>Bar</span>"
       ("cst<p>")
       "<p>Bar</p>"))
+  (ert-info ("optionally keep xml attributes: repeating")
+    (evil-test-buffer
+     :visual-start nil
+     :visual-end nil
+     "<div attr=\"foo\">Foo</div><div attr=\"bar\">Bar</div>"
+     (turn-on-evil-surround-mode)
+     ("cst<span")
+     "<span attr=\"foo\">Foo</span><div attr=\"bar\">Bar</div>"
+     ("fB.")
+     "<span attr=\"foo\">Foo</span><span attr=\"bar\">Bar</span>"))
   (ert-info ("repeat surrounding")
     (evil-test-buffer
       "[o]ne two three"


### PR DESCRIPTION
To make repeating tag changes work properly, we need to record the output from the reading the new tag.

Addresses #161 