### PR TITLE
NonGNU ELPA fixes: license statement + bump version

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -3,9 +3,6 @@
 ;; Copyright (C) 2010 - 2017 Tim Harper
 ;; Copyright (C) 2018 - 2020 The evil-surround.el Contributors
 
-;; Licensed under the same terms as Emacs (GPLv3)
-
-;;
 ;; Author: Tim Harper <timcharper at gmail dot com>
 ;;         Vegard Øye <vegard_oye at hotmail dot com>
 ;; Current Maintainer: ninrod (github.com/ninrod)
@@ -17,8 +14,21 @@
 ;;      Newsgroup: nntp://news.gmane.org/gmane.emacs.vim-emulation
 ;;      Archives: http://dir.gmane.org/gmane.emacs.vim-emulation
 ;; Keywords: emulation, vi, evil
-;;
+
 ;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 

--- a/evil-surround.el
+++ b/evil-surround.el
@@ -7,7 +7,7 @@
 ;;         Vegard Øye <vegard_oye at hotmail dot com>
 ;; Current Maintainer: ninrod (github.com/ninrod)
 ;; Created: July 23 2011
-;; Version: 1.0.3
+;; Version: 1.0.4
 ;; Package-Requires: ((evil "1.2.12"))
 ;; Mailing list: <implementations-list at lists.ourproject.org>
 ;;      Subscribe: http://tinyurl.com/implementations-list


### PR DESCRIPTION
Hi!

I am investigating if we could add this package to [NonGNU ELPA](http://elpa.nongnu.org/) (see link), a new Emacs Lisp package archive that will be enabled by default in Emacs 28. This means that users of that version or later will be able to install this package without any configuration: they can just run `M-x list-packages` and install it out of the box. We hope that this will improve Emacs and help bring new users to this package and others.

1. NonGNU ELPA has a requirement that all files must have a clear statement of its license. I believe the first patch here would be sufficient to fulfill this requirement.

2. The main difference between NonGNU ELPA and MELPA is that only stable versions of packages are released. A new release will be made automatically when you bump the ";; Version: NNN" commentary header in this repository, as I do in the second commit. NonGNU ELPA does not look at any "git tag". In the future, you can bump the package version in that header (thereby releasing a new version) when you think it makes sense and at your convenience.

The rules for accepting a package into NonGNU ELPA are here, for your reference:
https://git.savannah.gnu.org/cgit/emacs/nongnu.git/tree/README.org#n133

Besides the license statement, this package already follows the rules so there should be nothing more to do with regards to that. However, it would be good if you could review them and let us know if you think there will be any problems with following any of them going forward. They should be straightforward and easy to follow, but note in particular that NonGNU ELPA does not distribute any package that recommends proprietary software.

Please let me know if you have any questions about NonGNU ELPA.

Thanks!