### PR TITLE
Limit global activation to 'text-mode' and 'prog-mode'

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -493,7 +493,7 @@ Becomes this:
 ;;;###autoload
 (define-globalized-minor-mode global-evil-surround-mode
   evil-surround-mode turn-on-evil-surround-mode
-  "Global minor mode to emulate surround.vim.")
+  :predicate '(text-mode prog-mode comint-mode))
 
 (evil-define-key 'operator evil-surround-mode-map "s" 'evil-surround-edit)
 (evil-define-key 'operator evil-surround-mode-map "S" 'evil-Surround-edit)


### PR DESCRIPTION
Activating evil-surround in special-mode (i.e. read-only) buffers does not make
sense. Furthermore, the bindings can overwrite bindings in modes like
magit-diff-mode (see
https://github.com/syl20bnr/spacemacs/issues/15448#issuecomment-1090810486).

This commit limits the 'globally activated modes' to text-mode and prog-mode via
the `define-globalized-minor-mode` its
[:predicate](https://www.gnu.org/software/emacs/manual/html_node/elisp/Defining-Minor-Modes.html#index-define_002dglobalized_002dminor_002dmode]
keyword.

As this should be the default behavior, it is not essential to change the
documentation.