### PR TITLE
Fix some grammar quirks in readme.org

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -21,9 +21,9 @@ To enable it through [[https://github.com/jwiegley/use-package][use-package]], a
     (global-evil-surround-mode 1))
 #+END_SRC
 
-Alternatively, a user can add the =evil-surround.el= file to your load-path and add =(require 'evil-surround)= to your init file.
+Alternatively, you can add the =evil-surround.el= file to your load-path and add =(require 'evil-surround)= to your init file.
 
-Also, Instead of enabling it globally, you can also enable =surround-mode= along a major mode by adding =turn-on-surround-mode= to the mode hook.
+Also, instead of enabling it globally, you can also enable =surround-mode= for a given major mode by adding =turn-on-surround-mode= to the mode hook.
 
 * Usage
 ** Add surrounding


### PR DESCRIPTION
I was looking up the keybindings in the readme and noticed a few small grammar issues, so here's a quick fix for them.