### PR TITLE
fix yss in visual-line-mode

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -473,6 +473,7 @@ Becomes this:
                          (newline-and-indent))
                      (backward-char)
                      (evil-end-of-visual-line)
+					 (forward-char)
 				     (skip-syntax-backward " " (save-excursion (evil-beginning-of-visual-line) (point))))
                    (insert close)
                    (when (or force-new-line


### PR DESCRIPTION
When `visual-line-mode` is enabled, `yss` doesn't surround the last character of the line 